### PR TITLE
Change fontsize.js case

### DIFF
--- a/plugins/fontSizes.js
+++ b/plugins/fontSizes.js
@@ -1,0 +1,14 @@
+module.exports = ({ addUtilities, theme, e }) => {
+  const fontsizes = theme('gutenberg.fontSizes', {});
+  const utilities = {};
+
+  for (let [slug, fontSize] of Object.entries(fontsizes)) {
+    slug = slug.replace(/([0-9])([a-z])/g, '$1-$2'); // wp dashes these.
+    utilities[`.${e(`has-${slug}-font-size`)}`] = { 'font-size': fontSize };
+  }
+
+  addUtilities(utilities, {
+    respectPrefix: false,
+    respectImportant: true,
+  });
+};


### PR DESCRIPTION
There is a case mismatch in the filename and require statement which causes issues on certain operating systems at build time.